### PR TITLE
replaced type specification with diamond operator.

### DIFF
--- a/threadposter/build.gradle
+++ b/threadposter/build.gradle
@@ -50,6 +50,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
 }
 
 dependencies {

--- a/threadposter/src/main/java/com/techyourchance/threadposter/BackgroundThreadPoster.java
+++ b/threadposter/src/main/java/com/techyourchance/threadposter/BackgroundThreadPoster.java
@@ -54,7 +54,7 @@ public class BackgroundThreadPoster {
                 Integer.MAX_VALUE,
                 KEEP_ALIVE_SECONDS,
                 TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>()
+                new SynchronousQueue<>()
         );
     }
 


### PR DESCRIPTION
Java 7 introduced the diamond operator (<>) to reduce the verbosity of generics code. For instance, instead of having to declare a `SynchronousQueue` type in both its declaration and its constructor, you can now simplify the constructor declaration with <>, and the compiler will infer the type.

Also updated source/target java language compatibility with Java 1.8 to make use of Java's newer language features.