### PR TITLE
removed unused imports.

### DIFF
--- a/sample/src/test/java/com/techyourchance/threadposters/FetchDataUseCaseTest.java
+++ b/sample/src/test/java/com/techyourchance/threadposters/FetchDataUseCaseTest.java
@@ -4,9 +4,6 @@ import com.techyourchance.threadposter.testdoubles.ThreadPostersTestDouble;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;

--- a/threadposter/src/main/java/com/techyourchance/threadposter/testdoubles/BackgroundThreadPosterTestDouble.java
+++ b/threadposter/src/main/java/com/techyourchance/threadposter/testdoubles/BackgroundThreadPosterTestDouble.java
@@ -3,15 +3,12 @@ package com.techyourchance.threadposter.testdoubles;
 
 import com.techyourchance.threadposter.BackgroundThreadPoster;
 
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Test double of {@link BackgroundThreadPoster} that can be used in tests in order to establish

--- a/threadposter/src/main/java/com/techyourchance/threadposter/testdoubles/UiThreadPosterTestDouble.java
+++ b/threadposter/src/main/java/com/techyourchance/threadposter/testdoubles/UiThreadPosterTestDouble.java
@@ -4,7 +4,6 @@ import android.os.Handler;
 
 import com.techyourchance.threadposter.UiThreadPoster;
 
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 


### PR DESCRIPTION
Unused and useless imports reduces the code's readability, since their presence can be confusing.