### PR TITLE
added ability to configure the number of threads to keep in the pool and updated default thread pool count

### DIFF
--- a/threadposter/src/main/java/com/techyourchance/threadposter/BackgroundThreadPoster.java
+++ b/threadposter/src/main/java/com/techyourchance/threadposter/BackgroundThreadPoster.java
@@ -7,7 +7,8 @@ import java.util.concurrent.TimeUnit;
 
 public class BackgroundThreadPoster {
 
-    private static final int DEFAULT_CORE_THREADS_COUNT = 3;
+    private static final int DEFAULT_CORE_THREADS_COUNT = Runtime.getRuntime()
+            .availableProcessors();
     private static final long KEEP_ALIVE_SECONDS = 60L;
 
     private final ThreadPoolExecutor mThreadPoolExecutor;

--- a/threadposter/src/main/java/com/techyourchance/threadposter/BackgroundThreadPoster.java
+++ b/threadposter/src/main/java/com/techyourchance/threadposter/BackgroundThreadPoster.java
@@ -7,13 +7,17 @@ import java.util.concurrent.TimeUnit;
 
 public class BackgroundThreadPoster {
 
-    private static final int CORE_THREADS = 3;
+    private static final int DEFAULT_CORE_THREADS_COUNT = 3;
     private static final long KEEP_ALIVE_SECONDS = 60L;
 
     private final ThreadPoolExecutor mThreadPoolExecutor;
 
     public BackgroundThreadPoster() {
-        mThreadPoolExecutor = newThreadPoolExecutor();
+        mThreadPoolExecutor = newThreadPoolExecutor(DEFAULT_CORE_THREADS_COUNT);
+    }
+
+    public BackgroundThreadPoster(int coreThreads) {
+        mThreadPoolExecutor = newThreadPoolExecutor(coreThreads);
     }
 
     /**
@@ -48,9 +52,9 @@ public class BackgroundThreadPoster {
      * The returned executor has sensible defaults for Android applications.<br>
      * Override only if you're ABSOLUTELY sure that you know what you're doing.
      */
-    protected ThreadPoolExecutor newThreadPoolExecutor() {
+    protected ThreadPoolExecutor newThreadPoolExecutor(int coreThreads) {
         return new ThreadPoolExecutor(
-                CORE_THREADS,
+                coreThreads,
                 Integer.MAX_VALUE,
                 KEEP_ALIVE_SECONDS,
                 TimeUnit.SECONDS,


### PR DESCRIPTION
By default, the specified default number of threads (3) are used when
constructing the `ThreadPoolExecutor` object. However, this commit adds
a `BackgroundThreadPoster` constructor that takes an integer argument
used to override the default thread count value.